### PR TITLE
Accept data.world auth token via: docker --env DW_TOKEN=...

### DIFF
--- a/data.world-mondrian-demo/Dockerfile
+++ b/data.world-mondrian-demo/Dockerfile
@@ -17,3 +17,10 @@ COPY files/*.xml /usr/local/tomcat/shared/
 RUN mkdir -p /usr/local/tomcat/webapps/demo
 COPY files/index.html /usr/local/tomcat/webapps/demo/
 COPY files/demo.js /usr/local/tomcat/webapps/demo/
+
+COPY files/entrypoint.sh /
+CMD ["/entrypoint.sh"]
+EXPOSE 80
+
+# Start docker with --env DW_TOKEN="<your data.world auth token from https://data.world/settings/advanced>"
+ENV DW_TOKEN="<placeholder>"

--- a/data.world-mondrian-demo/files/entrypoint.sh
+++ b/data.world-mondrian-demo/files/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+# Fix up the auth token in the jdbc connection configuration
+if [ "$DW_TOKEN" == "<placeholder>" ]; then
+  echo 'Run docker with --env DW_TOKEN="<your data.world auth token>"'
+  exit 1
+fi
+perl -pi -e 's/%DW_TOKEN%/$ENV{"DW_TOKEN"}/' /usr/local/tomcat/shared/mondrian-connections.json
+
+catalina.sh run

--- a/data.world-mondrian-demo/files/mondrian-connections.json
+++ b/data.world-mondrian-demo/files/mondrian-connections.json
@@ -2,8 +2,8 @@
 	"PresidentialElectionResults2016" : {
 		"JdbcDriver" : "world.data.jdbc.Driver",
 		"Jdbc" : "jdbc:data:world:sql:data4democracy:election-transparency",
-		"JdbcUser" : "scottcame",
-		"JdbcPassword" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJwcm9kLXVzZXItY2xpZW50OnNjb3R0Y2FtZSIsImlzcyI6ImFnZW50OnNjb3R0Y2FtZTo6YzlmYmJjMDktMjg5Yi00YTY2LThlYTYtYTllNzk0MDFjNjIxIiwiaWF0IjoxNDg0MDk5MjQzLCJyb2xlIjpbInVzZXJfYXBpX3JlYWQiLCJ1c2VyX2FwaV93cml0ZSJdLCJnZW5lcmFsLXB1cnBvc2UiOnRydWV9.Q0Jua9GQw2P_EEjylqhRuMvzkgnC_gAYig0Mm4jQ__kTgTRSV3hDFxHo2DoBlMXRigKNWA-hoKZt26fgQuhfnw",
+		"JdbcUser" : "ignored",
+		"JdbcPassword" : "%DW_TOKEN%",
 		"Catalog" : "/PresidentialElectionResults2016.xml",
 		"Description" : "US Presidential Election 2016",
 		"IsDemo" : false


### PR DESCRIPTION
Example, replace `<paste-here>` in the command below with your api token from https://data.world/settings/advanced:
```
$ docker run --rm -p 8080:80 mondrian-demo
Run docker with --env DW_TOKEN="<your data.world auth token>"

$ docker run --rm -p 8080:80 --env DW_TOKEN="<paste-here>" mondrian-demo
...
30-Aug-2018 22:07:35.500 INFO [main] org.apache.catalina.startup.Catalina.start Server startup in 6713 ms
```